### PR TITLE
Switch `$oldFile` and `$newFile` when computing diff of submission source files

### DIFF
--- a/domjudge/webapp/src/Twig/TwigExtension.php
+++ b/domjudge/webapp/src/Twig/TwigExtension.php
@@ -787,7 +787,7 @@ JS;
     public function showDiff(SubmissionFile $newFile, SubmissionFile $oldFile)
     {
         $differ = new Differ;
-        return $this->parseSourceDiff($differ->diff($newFile->getSourcecode(), $oldFile->getSourcecode()));
+        return $this->parseSourceDiff($differ->diff($oldFile->getSourcecode(), $newFile->getSourcecode()));
     }
 
     /**


### PR DESCRIPTION
Currently, when uploading a new submission, the "diff to previous submission" shows the diff the wrong way around: Lines from the new submission start with a "-" and deleted lines start with a "+". This drives me crazy. I think I found the correct place to change the order of the files to be diffed, but I haven't tested.
